### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -1,15 +1,17 @@
-## SPDX-FileCopyrightText: 2016 Comcast Cable Communications Management, LLC
-## SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
 ---
 name: 'Dependabot auto approval'
 
 on:
-  pull_request_target
+  pull_request_target:
+
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-  package:
+  approve:
+    # yamllint disable-line
     uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -13,5 +13,6 @@ permissions:
 
 jobs:
   release:
-    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@5268009a77dc4857b9ced4b123cd2c3432ec4c58 # v4.9.7
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@5268009a77dc4857b9ced4b123cd2c3432ec4c58 # v4.9.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,16 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  contents:      write
+  packages:      write
+
 jobs:
   ci:
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@5268009a77dc4857b9ced4b123cd2c3432ec4c58 # v4.9.7
     with:
-      release-type:          program
+      release-type:          library
       release-arch-amd64:    true
       release-arch-arm64:    true
       release-docker:        true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,15 @@ on:
 
 permissions:
   pull-requests: read
-  contents:      write
-  packages:      write
+  contents: write
+  packages: write
 
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@5268009a77dc4857b9ced4b123cd2c3432ec4c58 # v4.9.7
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
-      release-type:          library
+      release-type:          program
       release-arch-amd64:    true
       release-arch-arm64:    true
       release-docker:        true

--- a/.github/workflows/dependabot-approver.yml
+++ b/.github/workflows/dependabot-approver.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,7 +11,12 @@ on:
     types:
       - opened
 
+permissions:
+  contents:       read
+  issues:         write
+  pull-requests:  write
+
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/proj.yml
+++ b/.github/workflows/proj.yml
@@ -1,5 +1,5 @@
-## SPDX-FileCopyrightText: 2016 Comcast Cable Communications Management, LLC
-## SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
 ---
 name: 'PROJ: xmidt-team'
 
@@ -12,11 +12,12 @@ on:
       - opened
 
 permissions:
-  contents:       read
-  issues:         write
-  pull-requests:  write
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
-  package:
+  proj:
+    # yamllint disable-line
     uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit


### PR DESCRIPTION
## Summary

Normalizes CI/CD workflows to match the xmidt-org ideal state as outlined in #206.

## Changes

- **ci.yml**: Changed `release-type` from `program` to `library` and added top-level `permissions` block
- **auto-releaser.yml**: Renamed from `auto-release.yml` and added top-level `permissions` block
- **dependabot-approver.yml**: Updated to use `xmidt-org/shared-go/.github/workflows/approve-dependabot.yml` and pinned to SHA
- **proj-xmidt-team.yml**: Updated to use `xmidt-org/shared-go/.github/workflows/proj.yml`, pinned to SHA, and added `permissions` block

All shared workflow references are now pinned to commit `aff0471aa7e2f96ddb059beb178f63747a7cc57e` (v4.9.41).

Closes #206